### PR TITLE
Fix missed sqrt for faces distance result

### DIFF
--- a/SameFace/CVUtils/CVUtilsInterface.swift
+++ b/SameFace/CVUtils/CVUtilsInterface.swift
@@ -43,6 +43,7 @@ public struct CVUtilsInterface {
         result += (Double(truncating: firstOutput[idx]) - Double(truncating: secondOutput[idx]))
           * (Double(truncating: firstOutput[idx]) - Double(truncating: secondOutput[idx]))
       }
+      result = result.squareRoot()
       print(result)
       return result < 1.0
     } catch {


### PR DESCRIPTION
Hello. Thanks for great work! I've compared using OpenFace with python source code and found that there is additional math sqrt operation at the end of computation of distance between
 two faces. This should give more precise faces distance comparison result.